### PR TITLE
replace overlapping structures with pointers for latest avr-gcc

### DIFF
--- a/voicecard/voice.cc
+++ b/voicecard/voice.cc
@@ -39,10 +39,10 @@ TransientGenerator transient_generator;
 
 /* <static> */
 
-uint8_t Voice::patch_data_[1];
 Patch Voice::patch_;
-uint8_t Voice::part_data_[1];
+uint8_t *Voice::patch_data_ = reinterpret_cast<uint8_t*> (&Voice::patch_);
 Part Voice::part_;
+uint8_t *Voice::part_data_ = reinterpret_cast<uint8_t*> (&Voice::part_);
 
 Lfo Voice::voice_lfo_;
 Envelope Voice::envelope_[kNumEnvelopes];
@@ -103,11 +103,6 @@ static const prog_Patch init_patch PROGMEM = {
   // Padding
   0, 0, 0, 0, 0, 0, 0, 0,
 };
-
-/* static */
-void Voice::set_patch_data(uint8_t address, uint8_t value) {
-  patch_data_[address + 1] = value;
-}
 
 /* static */
 void Voice::Init() {

--- a/voicecard/voice.h
+++ b/voicecard/voice.h
@@ -81,13 +81,14 @@ class Voice {
     modulation_sources_[i] = value;
   }
   
-  static void set_patch_data(uint8_t address, uint8_t value);
-  static void set_part_data(uint8_t address, uint8_t value) {
-    part_data_[address + 1] = value;
+  static void set_patch_data(uint8_t address, uint8_t value) {
+    patch_data_[address] = value;
   }
-  
+  static void set_part_data(uint8_t address, uint8_t value) {
+    part_data_[address] = value;
+  }
   static uint8_t* mutable_patch_data() {
-    return &patch_data_[1];
+    return patch_data_;
   }
   
   static const Patch& patch() { return patch_; }
@@ -104,9 +105,9 @@ class Voice {
   static inline void UpdateDestinations() __attribute__((always_inline));
   static inline void RenderOscillators() __attribute__((always_inline));
 
-  static uint8_t patch_data_[1];
+  static uint8_t *patch_data_;
   static Patch patch_;
-  static uint8_t part_data_[1];
+  static uint8_t *part_data_;
   static Part part_;
   
   // Envelope generators.


### PR DESCRIPTION
The original code is not working anymore with avr-gcc 9, possibly due to the fact that structures are not adjacent anymore... It also works with avr-gcc 4.3.3.